### PR TITLE
feature(cors): Enable CORS temporarily for dev

### DIFF
--- a/api.py
+++ b/api.py
@@ -1,6 +1,9 @@
 from flask import Flask, render_template, redirect, request, make_response
+from flask_cors import CORS
 import json
+
 app = Flask(__name__ , static_folder='templates/static', template_folder='templates')
+CORS(app)
 
 @app.route('/')
 def index():

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ click==6.7
 cryptography==2.0.3
 enum34==1.1.6
 Flask==0.12.2
+flask-cors==3.0.3
 idna==2.5
 ipaddress==1.0.18
 itsdangerous==0.24


### PR DESCRIPTION
I added the `flask-cors` library which can allow you to enable CORS on all routes, or just a single particular route.

In the meantime, for development purposes, I've enabled it on all routes to make it easier for you.  You can remove this or configure it to only be for certain routes when you deploy it to production.

You'll need to update your Python libraries to make sure you pick up the library:
```
$ pip install -r requirements.txt
```